### PR TITLE
With mapping

### DIFF
--- a/src/Application/Url/Commands/CreateShortUrlCommand.cs
+++ b/src/Application/Url/Commands/CreateShortUrlCommand.cs
@@ -36,7 +36,7 @@ public class CreateShortUrlCommandHandler : IRequestHandler<CreateShortUrlComman
     public async Task<string> Handle(CreateShortUrlCommand request, CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
-        var id = CalculateShortId(request.Url);
+        var id = CalculateShortId(request.Url); // Guid.NewGuid().ToString();  We could use Guid, but I wanted shorter IDs
         var shortUrl = "http://localhost:5246/u/" + id;
         _context.Urls.Add(new Domain.Entities.Url() 
         { 

--- a/src/Application/Url/Commands/RedirectToUrlCommand.cs
+++ b/src/Application/Url/Commands/RedirectToUrlCommand.cs
@@ -39,23 +39,7 @@ public class RedirectToUrlCommandHandler : IRequestHandler<RedirectToUrlCommand,
     public async Task<string> Handle(RedirectToUrlCommand request, CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
-        var decoded = decode(request.Id);
-        return new RedirectResult(decoded).Url;
-    }
-    public static byte[] FromHex(string hex)
-    {
-        hex = hex.Replace("-", "");
-        byte[] raw = new byte[hex.Length / 2];
-        for (int i = 0; i < raw.Length; i++)
-        {
-            raw[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
-        }
-    return raw;
-}
-
-    public string decode(string id) {
-        var hex = _hashids.DecodeHex(id);
-        byte[] data = FromHex(hex);
-        return Encoding.UTF8.GetString(data);
+        var url = _context.Urls.FirstOrDefault(url => url.Id == request.Id);
+        return new RedirectResult(url.OriginalUrl).Url;
     }
 }

--- a/src/Domain/Entities/Url.cs
+++ b/src/Domain/Entities/Url.cs
@@ -22,6 +22,10 @@ public class Url : BaseAuditableEntity
     /// The original url.
     /// </summary>
     public string OriginalUrl { get; set; } = default!;
+    /// <summary>
+    /// The short id.
+    /// </summary>
+    public string Id { get; set; } = default!;
 
     #endregion
 }


### PR DESCRIPTION
Right now the service works just by encoding & decoding the URL (deterministic hashes).

This change introduces the use of DB-context, to create a mapping from short_ID -> URL.

IDs no longer need to be decoded to the original URL, so they can be much shorter now.